### PR TITLE
Only delete the content of dist/ not the folder

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -5,7 +5,7 @@
   "source": "/html/index.html",
   "scripts": {
     "run": "parcel",
-    "build": "rm -rf dist && parcel build",
+    "build": "rm -rf dist/* && parcel build",
     "serve": "parcel watch",
     "tsc": "tsc --noEmit"
   },


### PR DESCRIPTION
I might have the wrong development flow for the client. But what I do is running ``npm run build`` and then going into dist/ and running a webserver there. After changing the code I run ``npm run build`` again to update the dist/ folder. But if it gets deleted my web server dies and i have to restart it.

This fixes my workflow :) 